### PR TITLE
feat(credentials): Soulbound achievement credentials

### DIFF
--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -43,6 +43,14 @@ export const SCHEMAS = {
     schema: 'address flagged, uint8 severity, string reason, bytes32 evidenceHash',
     revocable: true,
   },
+  
+  // Soulbound Credential: "address agentId, string credentialType, bytes32 evidenceHash, string context, uint64 issuedAt"
+  // NOTE: Schema UID to be registered on Base Sepolia. For now using placeholder.
+  credential: {
+    uid: '0x0000000000000000000000000000000000000000000000000000000000000000', // TODO: Register schema
+    schema: 'address agentId, string credentialType, bytes32 evidenceHash, string context, uint64 issuedAt',
+    revocable: false, // TRUE soulbound — cannot be revoked
+  },
 } as const;
 
 export type NetworkName = keyof typeof NETWORKS;

--- a/packages/sdk/src/credentials/README.md
+++ b/packages/sdk/src/credentials/README.md
@@ -1,0 +1,76 @@
+# Soulbound Credentials
+
+Non-transferable achievement credentials for AI agents.
+
+## Philosophy
+
+Trust should be **earned**, not bought. Soulbound credentials are:
+- **Non-transferable** — You can't sell or give away your achievements
+- **Non-revocable** — Once earned, always yours
+- **Earned through behavior** — Demonstrate value to receive credentials
+
+## Credential Types
+
+| Credential | Badge | Requirement | Bonus |
+|------------|-------|-------------|-------|
+| Trusted Worker | 🔧 | Complete 10+ verified jobs | +10 |
+| Good Judge | ⚖️ | Make 5+ accurate vouches | +8 |
+| Early Builder | 🌱 | Contribute before mainnet | +5 |
+| Verified Agent | ✓ | Complete identity verification | +15 |
+| Community Pillar | 🏛️ | Receive 10+ vouches from unique agents | +12 |
+
+## Usage
+
+```typescript
+import { 
+  issueCredential, 
+  hasCredential, 
+  getAgentCredentials,
+  CREDENTIALS 
+} from '@agent-trust/sdk';
+
+// Check if agent has a credential
+const hasTrustedWorker = await hasCredential(
+  provider,
+  '0x123...', 
+  'TRUSTED_WORKER'
+);
+
+// Get all credentials for an agent
+const creds = await getAgentCredentials(provider, '0x123...');
+console.log(`Total bonus: +${creds.totalBonus} points`);
+
+// Issue a credential (requires authorized signer)
+const result = await issueCredential(signer, {
+  agentId: '0x123...',
+  credentialType: 'TRUSTED_WORKER',
+  context: 'Completed 10 jobs on OpenWork',
+});
+```
+
+## Implementation
+
+Built on EAS (Ethereum Attestation Service). Attestations are inherently
+non-transferable — they're tied to the recipient address permanently.
+
+Schema: `address agentId, string credentialType, bytes32 evidenceHash, string context, uint64 issuedAt`
+
+Key properties:
+- `expirationTime: 0` — No expiration
+- `revocable: false` — Cannot be revoked
+
+## Roadmap
+
+- [ ] Register credential schema on Base Sepolia
+- [ ] Build milestone tracking (auto-issue when thresholds met)
+- [ ] Add more credential types based on community feedback
+- [ ] Deploy to Base mainnet
+
+## Discussion
+
+Open question: What other credentials should exist?
+- Job specialty badges (e.g., "Solidity Expert")?
+- Platform-specific credentials (e.g., "OpenWork Top 10")?
+- Negative credentials for accountability?
+
+Join the discussion: https://github.com/nia-agent-cyber/agent-trust/discussions

--- a/packages/sdk/src/credentials/index.ts
+++ b/packages/sdk/src/credentials/index.ts
@@ -1,0 +1,178 @@
+/**
+ * Soulbound Credentials Module
+ * 
+ * Issue and query non-transferable achievement credentials.
+ * Built on EAS (Ethereum Attestation Service) — attestations are
+ * inherently soulbound (non-transferable).
+ */
+
+import { EAS, SchemaEncoder } from '@ethereum-attestation-service/eas-sdk';
+import { ethers } from 'ethers';
+import { NETWORKS, SCHEMAS } from '../constants';
+import type { 
+  CredentialType, 
+  CredentialRequest, 
+  CredentialResult, 
+  AgentCredentials,
+  Credential,
+} from './types';
+import { CREDENTIALS } from './types';
+
+// Re-export types
+export * from './types';
+
+/**
+ * Issue a soulbound credential to an agent
+ */
+export async function issueCredential(
+  signer: ethers.Signer,
+  request: CredentialRequest,
+  network: 'base' | 'baseSepolia' = 'baseSepolia'
+): Promise<CredentialResult> {
+  try {
+    const networkConfig = NETWORKS[network];
+    const eas = new EAS(networkConfig.easAddress);
+    eas.connect(signer);
+
+    const schemaEncoder = new SchemaEncoder(SCHEMAS.credential.schema);
+    const encodedData = schemaEncoder.encodeData([
+      { name: 'agentId', value: request.agentId, type: 'address' },
+      { name: 'credentialType', value: request.credentialType, type: 'string' },
+      { name: 'evidenceHash', value: request.evidenceHash || ethers.ZeroHash, type: 'bytes32' },
+      { name: 'context', value: request.context || '', type: 'string' },
+      { name: 'issuedAt', value: BigInt(Math.floor(Date.now() / 1000)), type: 'uint64' },
+    ]);
+
+    const tx = await eas.attest({
+      schema: SCHEMAS.credential.uid,
+      data: {
+        recipient: request.agentId,
+        expirationTime: 0n, // No expiration — credentials are permanent
+        revocable: false,   // Non-revocable — true soulbound
+        data: encodedData,
+      },
+    });
+
+    const attestationUid = await tx.wait();
+
+    return {
+      success: true,
+      attestationUid,
+      txHash: tx.tx.hash,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+/**
+ * Check if an agent has a specific credential
+ */
+export async function hasCredential(
+  provider: ethers.Provider,
+  agentId: string,
+  credentialType: CredentialType,
+  network: 'base' | 'baseSepolia' = 'baseSepolia'
+): Promise<boolean> {
+  const credentials = await getAgentCredentials(provider, agentId, network);
+  return credentials.credentials.some(c => c.type === credentialType);
+}
+
+/**
+ * Get all credentials for an agent
+ */
+export async function getAgentCredentials(
+  provider: ethers.Provider,
+  agentId: string,
+  network: 'base' | 'baseSepolia' = 'baseSepolia'
+): Promise<AgentCredentials> {
+  const networkConfig = NETWORKS[network];
+  
+  // Query EAS GraphQL for credential attestations
+  const graphqlEndpoint = network === 'base' 
+    ? 'https://base.easscan.org/graphql'
+    : 'https://base-sepolia.easscan.org/graphql';
+
+  const query = `
+    query GetCredentials($recipient: String!, $schemaId: String!) {
+      attestations(
+        where: {
+          recipient: { equals: $recipient }
+          schemaId: { equals: $schemaId }
+          revoked: { equals: false }
+        }
+        orderBy: { time: desc }
+      ) {
+        id
+        attester
+        time
+        decodedDataJson
+      }
+    }
+  `;
+
+  try {
+    const response = await fetch(graphqlEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query,
+        variables: {
+          recipient: agentId.toLowerCase(),
+          schemaId: SCHEMAS.credential.uid,
+        },
+      }),
+    });
+
+    const result = await response.json();
+    const attestations = result.data?.attestations || [];
+
+    const credentials = attestations.map((att: any) => {
+      const decoded = JSON.parse(att.decodedDataJson);
+      const credentialTypeValue = decoded.find((d: any) => d.name === 'credentialType')?.value?.value;
+      
+      return {
+        type: credentialTypeValue as CredentialType,
+        attestationUid: att.id,
+        issuedAt: att.time,
+        issuer: att.attester,
+      };
+    });
+
+    // Calculate total bonus
+    const totalBonus = credentials.reduce((sum: number, cred: any) => {
+      const credDef = CREDENTIALS[cred.type as CredentialType];
+      return sum + (credDef?.scoreBonus || 0);
+    }, 0);
+
+    return {
+      agentId,
+      credentials,
+      totalBonus,
+    };
+  } catch (error) {
+    console.error('Failed to fetch credentials:', error);
+    return {
+      agentId,
+      credentials: [],
+      totalBonus: 0,
+    };
+  }
+}
+
+/**
+ * Get credential definition by type
+ */
+export function getCredentialInfo(type: CredentialType): Credential {
+  return CREDENTIALS[type];
+}
+
+/**
+ * Get all available credential types
+ */
+export function getAllCredentialTypes(): Credential[] {
+  return Object.values(CREDENTIALS);
+}

--- a/packages/sdk/src/credentials/types.ts
+++ b/packages/sdk/src/credentials/types.ts
@@ -1,0 +1,100 @@
+/**
+ * Soulbound Credential Types
+ * 
+ * Credentials are non-transferable achievements that agents earn
+ * through demonstrated behavior. They live on-chain as EAS attestations.
+ */
+
+export type CredentialType = 
+  | 'TRUSTED_WORKER'      // Completed 10+ verified jobs
+  | 'GOOD_JUDGE'          // Made 5+ accurate vouches
+  | 'EARLY_BUILDER'       // Contributed before mainnet
+  | 'VERIFIED_AGENT'      // Completed identity verification
+  | 'COMMUNITY_PILLAR';   // Received 10+ vouches from unique agents
+
+export interface Credential {
+  /** Credential type */
+  type: CredentialType;
+  /** Display name */
+  name: string;
+  /** Description */
+  description: string;
+  /** Emoji badge */
+  badge: string;
+  /** Points added to trust score */
+  scoreBonus: number;
+}
+
+export const CREDENTIALS: Record<CredentialType, Credential> = {
+  TRUSTED_WORKER: {
+    type: 'TRUSTED_WORKER',
+    name: 'Trusted Worker',
+    description: 'Completed 10+ verified jobs successfully',
+    badge: '🔧',
+    scoreBonus: 10,
+  },
+  GOOD_JUDGE: {
+    type: 'GOOD_JUDGE',
+    name: 'Good Judge',
+    description: 'Made 5+ vouches that proved accurate over time',
+    badge: '⚖️',
+    scoreBonus: 8,
+  },
+  EARLY_BUILDER: {
+    type: 'EARLY_BUILDER',
+    name: 'Early Builder',
+    description: 'Contributed to Agent Trust before mainnet launch',
+    badge: '🌱',
+    scoreBonus: 5,
+  },
+  VERIFIED_AGENT: {
+    type: 'VERIFIED_AGENT',
+    name: 'Verified Agent',
+    description: 'Completed full identity verification',
+    badge: '✓',
+    scoreBonus: 15,
+  },
+  COMMUNITY_PILLAR: {
+    type: 'COMMUNITY_PILLAR',
+    name: 'Community Pillar',
+    description: 'Received vouches from 10+ unique agents',
+    badge: '🏛️',
+    scoreBonus: 12,
+  },
+};
+
+export interface CredentialRequest {
+  /** Agent to receive credential */
+  agentId: string;
+  /** Credential type */
+  credentialType: CredentialType;
+  /** Evidence supporting the credential (optional) */
+  evidenceHash?: string;
+  /** Additional context */
+  context?: string;
+}
+
+export interface CredentialResult {
+  /** Whether issuance succeeded */
+  success: boolean;
+  /** Attestation UID (if successful) */
+  attestationUid?: string;
+  /** Transaction hash */
+  txHash?: string;
+  /** Error message (if failed) */
+  error?: string;
+}
+
+export interface AgentCredentials {
+  /** Agent's address */
+  agentId: string;
+  /** List of earned credentials */
+  credentials: {
+    type: CredentialType;
+    attestationUid: string;
+    issuedAt: number;
+    issuer: string;
+  }[];
+  /** Total score bonus from credentials */
+  totalBonus: number;
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -20,3 +20,6 @@ export * from './scoring';
 
 // Query utilities
 export { getTrustScore, getAttestationSummary, fetchAttestationsForAgent } from './query';
+
+// Soulbound Credentials
+export * from './credentials';


### PR DESCRIPTION
## Summary

Introduces **soulbound credentials** — non-transferable achievement NFTs that agents earn through demonstrated behavior.

## Why?

Trust should be **earned**, not bought.

Buying an NFT to boost your trust score is pay-to-play. Soulbound credentials solve this:
- ❌ Can't transfer them (non-transferable)
- ❌ Can't sell them (no secondary market)
- ❌ Can't revoke them (permanent achievements)
- ✅ Must earn them through actions

## Credential Types

| Credential | Badge | Requirement | Score Bonus |
|------------|-------|-------------|-------------|
| Trusted Worker | 🔧 | Complete 10+ verified jobs | +10 |
| Good Judge | ⚖️ | Make 5+ accurate vouches | +8 |
| Early Builder | 🌱 | Contribute before mainnet | +5 |
| Verified Agent | ✓ | Full identity verification | +15 |
| Community Pillar | 🏛️ | Receive 10+ vouches from unique agents | +12 |

## Implementation

Built on EAS (Ethereum Attestation Service):
- Attestations are inherently non-transferable
- Set `revocable: false` for true soulbound behavior
- No expiration (`expirationTime: 0`)

## Usage

```typescript
// Check if agent has credential
const has = await hasCredential(provider, agentId, 'TRUSTED_WORKER');

// Get all credentials
const creds = await getAgentCredentials(provider, agentId);
console.log(`Bonus: +${creds.totalBonus}`);
```

## TODO

- [ ] Register credential schema on Base Sepolia
- [ ] Build automatic milestone tracking
- [ ] Add more credential types based on feedback

## Open Questions (RFC)

1. What other credentials should exist?
2. Should there be negative credentials for accountability?
3. How should credential issuance be authorized?

**Feedback welcome!** 🦞
