### PR TITLE
feat: MCP server for Claude Desktop (#31)

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,85 @@
+# @nia-agent-cyber/agent-trust-mcp
+
+MCP server that exposes Agent Trust SDK attestation tools to Claude Desktop and any MCP-compatible agent runtime.
+
+## Install
+
+```bash
+npm install -g @nia-agent-cyber/agent-trust-mcp
+```
+
+## Claude Desktop Setup
+
+Add this to your `claude_desktop_config.json` (usually at `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "agent-trust": {
+      "command": "agent-trust-mcp",
+      "env": {
+        "AGENT_TRUST_PRIVATE_KEY": "optional - only needed for issuing attestations"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after saving. You should see the three tools available in the tool picker.
+
+## Tools
+
+### `agent_trust_check`
+
+Get the trust tier and score for an agent Ethereum address. Returns tier level (0–4), tier name, score (0–100), and attestation count. Read-only — no private key required.
+
+**Inputs:** `address` (required), `network` (`base` | `base-sepolia`, default: `base`)
+
+### `agent_trust_issue`
+
+Issue an on-chain trust attestation for another agent. Requires `AGENT_TRUST_PRIVATE_KEY` to be set in the environment. Supports three attestation types:
+
+- **PaymentReliable** — record a payment interaction (amount, currency, outcome)
+- **TaskCompletion** — record a task completion (taskId, category, outcome, reward)
+- **SecurityAudit** — record a security audit result (auditType, passed, severity)
+
+**Inputs:** `type` (required), `subjectAgent` (required), plus type-specific fields, `network`
+
+### `agent_trust_query`
+
+Fetch the full attestation history for an agent address. Returns PaymentReliable, TaskCompletion, and/or SecurityAudit attestation arrays along with a summary count. Read-only — no private key required.
+
+**Inputs:** `address` (required), `type` (`PaymentReliable` | `TaskCompletion` | `SecurityAudit` | `all`, default: `all`), `network`
+
+## Example Usage
+
+Once connected in Claude Desktop, you can ask:
+
+> "Check the trust score for agent 0xabc...123 on Base"
+
+> "What attestations does 0xdef...456 have? Show me their task completion history."
+
+> "Issue a PaymentReliable attestation for 0xghi...789 — they paid 1.5 ETH on time."
+
+## Local Development
+
+```bash
+# From repo root
+cd packages/mcp
+npm install
+npm run build
+npm test
+```
+
+To test with Claude Desktop locally (before publishing), use the full path to the built binary:
+
+```json
+{
+  "mcpServers": {
+    "agent-trust": {
+      "command": "node",
+      "args": ["/path/to/agent-trust/packages/mcp/dist/bin/agent-trust-mcp.js"]
+    }
+  }
+}
+```

--- a/packages/mcp/bin/agent-trust-mcp.ts
+++ b/packages/mcp/bin/agent-trust-mcp.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+/**
+ * CLI entry point for Claude Desktop integration.
+ * Uses stdio transport so Claude Desktop can spawn this as a subprocess.
+ */
+import { createMcpServer } from '../src/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+const server = createMcpServer();
+const transport = new StdioServerTransport();
+server.connect(transport);

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@nia-agent-cyber/agent-trust-mcp",
+  "version": "0.1.0",
+  "description": "MCP server for Agent Trust SDK — exposes trust attestation tools to Claude Desktop and MCP-compatible runtimes",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "bin": {
+    "agent-trust-mcp": "dist/bin/agent-trust-mcp.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest --run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@nia-agent-cyber/agent-trust-sdk": "*",
+    "ethers": "^6.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  },
+  "author": "Nia <nia@agentmail.to>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nia-agent-cyber/agent-trust.git",
+    "directory": "packages/mcp"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  }
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @nia-agent-cyber/agent-trust-mcp
+ * MCP server exposing Agent Trust SDK as Claude Desktop tools
+ */
+
+export { createMcpServer } from './server.js';
+export type { CheckInput, CheckOutput, IssueInput, IssueOutput, QueryInput, QueryOutput } from './types.js';

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,0 +1,156 @@
+/**
+ * MCP server setup — registers agent_trust_check, agent_trust_issue, agent_trust_query tools
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { runCheck } from './tools/check.js';
+import { runIssue } from './tools/issue.js';
+import { runQuery } from './tools/query.js';
+import type { CheckInput, IssueInput, QueryInput } from './types.js';
+
+export function createMcpServer(): Server {
+  const server = new Server(
+    { name: 'agent-trust', version: '0.1.0' },
+    { capabilities: { tools: {} } }
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      {
+        name: 'agent_trust_check',
+        description:
+          'Get the trust tier and score for an agent Ethereum address. Returns tier level (0-4), tier name, score (0-100), and attestation count. Use this to check if an agent is trustworthy before interacting with it.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            address: {
+              type: 'string',
+              description: 'Ethereum address of the agent to check (0x...)',
+            },
+            network: {
+              type: 'string',
+              enum: ['base', 'base-sepolia'],
+              description: 'Network to query (default: base)',
+            },
+          },
+          required: ['address'],
+        },
+      },
+      {
+        name: 'agent_trust_issue',
+        description:
+          'Issue a trust attestation for an agent. Requires AGENT_TRUST_PRIVATE_KEY env var. Supports three attestation types: PaymentReliable (payment history), TaskCompletion (task outcomes), SecurityAudit (audit results).',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            type: {
+              type: 'string',
+              enum: ['PaymentReliable', 'TaskCompletion', 'SecurityAudit'],
+              description: 'Type of attestation to issue',
+            },
+            subjectAgent: {
+              type: 'string',
+              description: 'Ethereum address of the agent being attested (0x...)',
+            },
+            network: {
+              type: 'string',
+              enum: ['base', 'base-sepolia'],
+              description: 'Network to write to (default: base)',
+            },
+            amount: { type: 'number', description: 'Payment amount (PaymentReliable)' },
+            currency: { type: 'string', description: 'Payment currency, e.g. ETH (PaymentReliable)' },
+            outcome: {
+              type: 'string',
+              enum: ['paid', 'partial', 'failed'],
+              description: 'Payment outcome (PaymentReliable)',
+            },
+            paidAt: { type: 'number', description: 'Unix timestamp of payment (PaymentReliable)' },
+            taskId: { type: 'string', description: 'Task identifier (TaskCompletion)' },
+            category: { type: 'string', description: 'Task category (TaskCompletion)' },
+            taskOutcome: {
+              type: 'string',
+              enum: ['completed', 'failed', 'disputed'],
+              description: 'Task outcome (TaskCompletion)',
+            },
+            completedAt: { type: 'number', description: 'Unix timestamp of completion (TaskCompletion)' },
+            reward: { type: 'number', description: 'Reward amount (TaskCompletion)' },
+            rewardToken: { type: 'string', description: 'Reward token address (TaskCompletion)' },
+            taskRef: { type: 'string', description: 'External task reference URL or ID (TaskCompletion)' },
+            subject: { type: 'string', description: 'Subject address or contract (SecurityAudit)' },
+            auditType: { type: 'string', description: 'Type of audit performed (SecurityAudit)' },
+            passed: { type: 'boolean', description: 'Whether audit passed (SecurityAudit)' },
+            severity: {
+              type: 'number',
+              description: 'Severity level 0-4: 0=none, 1=low, 2=medium, 3=high, 4=critical (SecurityAudit)',
+            },
+            auditRef: { type: 'string', description: 'Audit report reference URL (SecurityAudit)' },
+          },
+          required: ['type', 'subjectAgent'],
+        },
+      },
+      {
+        name: 'agent_trust_query',
+        description:
+          'Fetch full attestation history for an agent address. Returns PaymentReliable, TaskCompletion, and/or SecurityAudit attestations with a summary count. Use this to research an agent\'s track record in detail.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            address: {
+              type: 'string',
+              description: 'Agent address to query (0x...)',
+            },
+            type: {
+              type: 'string',
+              enum: ['PaymentReliable', 'TaskCompletion', 'SecurityAudit', 'all'],
+              description: 'Attestation type to fetch (default: all)',
+            },
+            network: {
+              type: 'string',
+              enum: ['base', 'base-sepolia'],
+              description: 'Network to query (default: base)',
+            },
+          },
+          required: ['address'],
+        },
+      },
+    ],
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+
+    try {
+      if (name === 'agent_trust_check') {
+        const result = await runCheck(args as unknown as CheckInput);
+        return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+      }
+
+      if (name === 'agent_trust_issue') {
+        const result = await runIssue(args as unknown as IssueInput);
+        return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+      }
+
+      if (name === 'agent_trust_query') {
+        const result = await runQuery(args as unknown as QueryInput);
+        return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+      }
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ error: `Unknown tool: ${name}` }) }],
+        isError: true,
+      };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+        isError: true,
+      };
+    }
+  });
+
+  return server;
+}

--- a/packages/mcp/src/tools/check.ts
+++ b/packages/mcp/src/tools/check.ts
@@ -1,0 +1,72 @@
+/**
+ * agent_trust_check — get trust tier and score for an agent address
+ */
+
+import { ethers } from 'ethers';
+import { AgentTrust } from '@nia-agent-cyber/agent-trust-sdk';
+import type { CheckInput, CheckOutput, SdkNetworkName } from '../types.js';
+
+const ETH_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+
+function rpcUrl(network: string): string {
+  return network === 'base' ? 'https://mainnet.base.org' : 'https://sepolia.base.org';
+}
+
+function toSdkNetwork(network: string): SdkNetworkName {
+  return network === 'base-sepolia' ? 'baseSepolia' : 'base';
+}
+
+export async function runCheck(input: CheckInput): Promise<CheckOutput> {
+  const address = (input.address ?? '').trim();
+
+  if (!ETH_ADDRESS_RE.test(address)) {
+    return errorResult(address, 'Invalid address: must be a valid Ethereum address (0x...)');
+  }
+
+  const network = input.network ?? 'base';
+
+  try {
+    const provider = new ethers.JsonRpcProvider(rpcUrl(network));
+    const trust = new AgentTrust({ network: toSdkNetwork(network), provider });
+
+    const [tierResult, scoreResult] = await Promise.all([
+      trust.getTier(address),
+      trust.getScore(address),
+    ]);
+
+    const tier: number = typeof tierResult === 'number' ? tierResult : (tierResult as { tier: number }).tier;
+    const tierName: string =
+      typeof tierResult === 'object' && tierResult !== null && 'tierName' in tierResult
+        ? (tierResult as { tierName: string }).tierName
+        : tierNumberToName(tier);
+
+    const score: number = typeof scoreResult === 'number' ? scoreResult : (scoreResult as { score: number }).score;
+    const attestationCount: number =
+      typeof scoreResult === 'object' && scoreResult !== null && 'attestationCount' in scoreResult
+        ? (scoreResult as { attestationCount: number }).attestationCount
+        : 0;
+    const updatedAt: number | null =
+      typeof scoreResult === 'object' && scoreResult !== null && 'updatedAt' in scoreResult
+        ? ((scoreResult as { updatedAt?: number | null }).updatedAt ?? null)
+        : null;
+
+    return { address, tier, tierName, score, attestationCount, updatedAt };
+  } catch (err: unknown) {
+    return errorResult(address, err instanceof Error ? err.message : String(err));
+  }
+}
+
+function tierNumberToName(tier: number): string {
+  const names: Record<number, string> = {
+    0: 'New',
+    1: 'Contributor',
+    2: 'Trusted',
+    3: 'Verified',
+    4: 'Expert',
+  };
+  return names[tier] ?? 'Unknown';
+}
+
+function errorResult(address: string, error: string): CheckOutput {
+  return { address, tier: 0, tierName: 'New', score: 0, attestationCount: 0, updatedAt: null, error };
+}

--- a/packages/mcp/src/tools/issue.ts
+++ b/packages/mcp/src/tools/issue.ts
@@ -1,0 +1,121 @@
+/**
+ * agent_trust_issue — issue a trust attestation for an agent
+ */
+
+import { ethers } from 'ethers';
+import { AgentTrust } from '@nia-agent-cyber/agent-trust-sdk';
+import type { IssueInput, IssueOutput, SdkNetworkName } from '../types.js';
+
+const ETH_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+
+function rpcUrl(network: string): string {
+  return network === 'base' ? 'https://mainnet.base.org' : 'https://sepolia.base.org';
+}
+
+function toSdkNetwork(network: string): SdkNetworkName {
+  return network === 'base-sepolia' ? 'baseSepolia' : 'base';
+}
+
+export async function runIssue(input: IssueInput): Promise<IssueOutput> {
+  const privateKey = process.env['AGENT_TRUST_PRIVATE_KEY'];
+  if (!privateKey) {
+    return {
+      success: false,
+      error: 'Set AGENT_TRUST_PRIVATE_KEY env var to enable attestation issuance.',
+    };
+  }
+
+  const subjectAgent = (input.subjectAgent ?? '').trim();
+  if (!ETH_ADDRESS_RE.test(subjectAgent)) {
+    return { success: false, error: 'Invalid subjectAgent: must be a valid Ethereum address (0x...)' };
+  }
+
+  if (!input.type) {
+    return { success: false, error: 'Missing required field: type (PaymentReliable | TaskCompletion | SecurityAudit)' };
+  }
+
+  const network = input.network ?? 'base';
+
+  try {
+    const provider = new ethers.JsonRpcProvider(rpcUrl(network));
+    const wallet = new ethers.Wallet(privateKey, provider);
+    const trust = new AgentTrust({ network: toSdkNetwork(network), provider: wallet });
+
+    if (input.type === 'PaymentReliable') {
+      const result = await trust.issuePaymentReliable({
+        subjectAgent,
+        amount: input.amount ?? 0,
+        currency: input.currency ?? 'ETH',
+        outcome: mapPaymentOutcome(input.outcome),
+        dueAt: input.paidAt ?? Math.floor(Date.now() / 1000),
+        paidAt: input.paidAt ?? Math.floor(Date.now() / 1000),
+      });
+      return {
+        success: true,
+        attestationUid: result.attestationUid,
+        txHash: result.txHash,
+      };
+    }
+
+    if (input.type === 'TaskCompletion') {
+      const result = await trust.issueTaskCompletion({
+        subjectAgent,
+        taskId: input.taskId ?? '',
+        category: input.category ?? 'general',
+        outcome: mapTaskOutcome(input.taskOutcome),
+        completedAt: input.completedAt ?? Math.floor(Date.now() / 1000),
+        reward: input.reward,
+        rewardToken: input.rewardToken,
+        taskRef: input.taskRef,
+      });
+      return {
+        success: true,
+        attestationUid: result.attestationUid,
+        txHash: result.txHash,
+      };
+    }
+
+    if (input.type === 'SecurityAudit') {
+      const result = await trust.issueSecurityAudit({
+        auditor: wallet.address,
+        subject: input.subject ?? subjectAgent,
+        auditType: input.auditType ?? 'general',
+        passed: input.passed ?? false,
+        severity: mapSeverity(input.severity),
+        reportUri: input.auditRef,
+      });
+      return {
+        success: true,
+        attestationUid: result.attestationUid,
+        txHash: result.txHash,
+      };
+    }
+
+    return { success: false, error: `Unknown attestation type: ${input.type}` };
+  } catch (err: unknown) {
+    return { success: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function mapPaymentOutcome(outcome?: string): 'paid_on_time' | 'paid_late' | 'defaulted' {
+  if (outcome === 'paid') return 'paid_on_time';
+  if (outcome === 'partial') return 'paid_late';
+  return 'defaulted';
+}
+
+function mapTaskOutcome(outcome?: string): 'completed' | 'failed' | 'disputed' {
+  if (outcome === 'completed') return 'completed';
+  if (outcome === 'disputed') return 'disputed';
+  return 'failed';
+}
+
+function mapSeverity(severity?: number): 'none' | 'low' | 'medium' | 'high' | 'critical' {
+  const map: Record<number, 'none' | 'low' | 'medium' | 'high' | 'critical'> = {
+    0: 'none',
+    1: 'low',
+    2: 'medium',
+    3: 'high',
+    4: 'critical',
+  };
+  return (severity !== undefined && map[severity]) ? map[severity] : 'none';
+}

--- a/packages/mcp/src/tools/query.ts
+++ b/packages/mcp/src/tools/query.ts
@@ -1,0 +1,72 @@
+/**
+ * agent_trust_query — fetch attestation history for an agent
+ */
+
+import { ethers } from 'ethers';
+import { AgentTrust } from '@nia-agent-cyber/agent-trust-sdk';
+import type { QueryInput, QueryOutput, SdkNetworkName } from '../types.js';
+
+const ETH_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+
+function rpcUrl(network: string): string {
+  return network === 'base' ? 'https://mainnet.base.org' : 'https://sepolia.base.org';
+}
+
+function toSdkNetwork(network: string): SdkNetworkName {
+  return network === 'base-sepolia' ? 'baseSepolia' : 'base';
+}
+
+export async function runQuery(input: QueryInput): Promise<QueryOutput> {
+  const address = (input.address ?? '').trim();
+
+  if (!ETH_ADDRESS_RE.test(address)) {
+    return errorResult(address, 'Invalid address: must be a valid Ethereum address (0x...)');
+  }
+
+  const network = input.network ?? 'base';
+  const type = input.type ?? 'all';
+
+  try {
+    const provider = new ethers.JsonRpcProvider(rpcUrl(network));
+    const trust = new AgentTrust({ network: toSdkNetwork(network), provider });
+
+    let paymentReliable: unknown[] | undefined;
+    let taskCompletion: unknown[] | undefined;
+    let securityAudit: unknown[] | undefined;
+
+    if (type === 'all' || type === 'PaymentReliable') {
+      paymentReliable = await trust.getPaymentReliability(address);
+    }
+    if (type === 'all' || type === 'TaskCompletion') {
+      taskCompletion = await trust.getTaskCompletions(address);
+    }
+    if (type === 'all' || type === 'SecurityAudit') {
+      securityAudit = await trust.getSecurityAudits(address);
+    }
+
+    const byType: Record<string, number> = {};
+    if (paymentReliable !== undefined) byType['PaymentReliable'] = paymentReliable.length;
+    if (taskCompletion !== undefined) byType['TaskCompletion'] = taskCompletion.length;
+    if (securityAudit !== undefined) byType['SecurityAudit'] = securityAudit.length;
+
+    const totalAttestations = Object.values(byType).reduce((a, b) => a + b, 0);
+
+    return {
+      address,
+      paymentReliable,
+      taskCompletion,
+      securityAudit,
+      summary: { totalAttestations, byType },
+    };
+  } catch (err: unknown) {
+    return errorResult(address, err instanceof Error ? err.message : String(err));
+  }
+}
+
+function errorResult(address: string, error: string): QueryOutput {
+  return {
+    address,
+    summary: { totalAttestations: 0, byType: {} },
+    error,
+  };
+}

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared types for MCP tool inputs and outputs
+ */
+
+// User-facing network names (mapped to SDK names internally)
+export type NetworkName = 'base' | 'base-sepolia';
+// SDK internal network name
+export type SdkNetworkName = 'base' | 'baseSepolia';
+
+export type AttestationType = 'PaymentReliable' | 'TaskCompletion' | 'SecurityAudit';
+
+// ─── agent_trust_check ────────────────────────────────────────────────────────
+
+export interface CheckInput {
+  address: string;
+  network?: NetworkName;
+}
+
+export interface CheckOutput {
+  address: string;
+  tier: number;
+  tierName: string;
+  score: number;
+  attestationCount: number;
+  updatedAt: number | null;
+  error?: string;
+}
+
+// ─── agent_trust_issue ────────────────────────────────────────────────────────
+
+export interface IssueInput {
+  type: AttestationType;
+  subjectAgent: string;
+  network?: NetworkName;
+  // PaymentReliable
+  amount?: number;
+  currency?: string;
+  outcome?: 'paid' | 'partial' | 'failed';
+  paidAt?: number;
+  // TaskCompletion
+  taskId?: string;
+  category?: string;
+  taskOutcome?: 'completed' | 'failed' | 'disputed';
+  completedAt?: number;
+  reward?: number;
+  rewardToken?: string;
+  taskRef?: string;
+  // SecurityAudit
+  subject?: string;
+  auditType?: string;
+  passed?: boolean;
+  severity?: number;
+  auditRef?: string;
+}
+
+export interface IssueOutput {
+  success: boolean;
+  attestationUid?: string;
+  txHash?: string;
+  error?: string;
+}
+
+// ─── agent_trust_query ────────────────────────────────────────────────────────
+
+export interface QueryInput {
+  address: string;
+  type?: AttestationType | 'all';
+  network?: NetworkName;
+}
+
+export interface QueryOutput {
+  address: string;
+  paymentReliable?: unknown[];
+  taskCompletion?: unknown[];
+  securityAudit?: unknown[];
+  summary: {
+    totalAttestations: number;
+    byType: Record<string, number>;
+  };
+  error?: string;
+}

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mock ethers ─────────────────────────────────────────────────────────────
+vi.mock('ethers', () => ({
+  ethers: {
+    JsonRpcProvider: vi.fn().mockImplementation(() => ({})),
+    Wallet: vi.fn().mockImplementation((key: string, provider: unknown) => ({ key, provider })),
+  },
+}));
+
+// ─── Mock AgentTrust SDK ──────────────────────────────────────────────────────
+const mockTrust = {
+  getTier: vi.fn(),
+  getScore: vi.fn(),
+  getPaymentReliability: vi.fn(),
+  getTaskCompletions: vi.fn(),
+  getSecurityAudits: vi.fn(),
+  issuePaymentReliable: vi.fn(),
+  issueTaskCompletion: vi.fn(),
+  issueSecurityAudit: vi.fn(),
+};
+
+vi.mock('@nia-agent-cyber/agent-trust-sdk', () => ({
+  AgentTrust: vi.fn().mockImplementation(() => mockTrust),
+}));
+
+import { runCheck } from '../src/tools/check.js';
+import { runIssue } from '../src/tools/issue.js';
+import { runQuery } from '../src/tools/query.js';
+
+const VALID_ADDR = '0x' + 'a'.repeat(40);
+const ZERO_ADDR = '0x' + '0'.repeat(40);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env['AGENT_TRUST_PRIVATE_KEY'];
+});
+
+// ─── agent_trust_check ────────────────────────────────────────────────────────
+
+describe('runCheck', () => {
+  it('returns tier and score for a valid address', async () => {
+    mockTrust.getTier.mockResolvedValue({ tier: 2, tierName: 'Trusted' });
+    mockTrust.getScore.mockResolvedValue({ score: 75, attestationCount: 10, updatedAt: 1700000000 });
+
+    const result = await runCheck({ address: VALID_ADDR });
+
+    expect(result.address).toBe(VALID_ADDR);
+    expect(result.tier).toBe(2);
+    expect(result.tierName).toBe('Trusted');
+    expect(result.score).toBe(75);
+    expect(result.attestationCount).toBe(10);
+    expect(result.updatedAt).toBe(1700000000);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('falls back to numeric tier name when tierName not in result', async () => {
+    mockTrust.getTier.mockResolvedValue({ tier: 1 });
+    mockTrust.getScore.mockResolvedValue({ score: 50 });
+
+    const result = await runCheck({ address: VALID_ADDR });
+    expect(result.tierName).toBe('Contributor');
+  });
+
+  it('handles getTier returning a plain number', async () => {
+    mockTrust.getTier.mockResolvedValue(3);
+    mockTrust.getScore.mockResolvedValue({ score: 80 });
+
+    const result = await runCheck({ address: VALID_ADDR });
+    expect(result.tier).toBe(3);
+    expect(result.tierName).toBe('Verified');
+  });
+
+  it('returns error for invalid address', async () => {
+    const result = await runCheck({ address: 'not-an-address' });
+    expect(result.error).toMatch(/invalid address/i);
+    expect(result.tier).toBe(0);
+    expect(mockTrust.getTier).not.toHaveBeenCalled();
+  });
+
+  it('returns error for zero address', async () => {
+    const result = await runCheck({ address: ZERO_ADDR });
+    expect(result.error).toBeUndefined(); // zero address is technically valid hex
+    expect(mockTrust.getTier).toHaveBeenCalled();
+  });
+
+  it('returns error for empty address', async () => {
+    const result = await runCheck({ address: '' });
+    expect(result.error).toMatch(/invalid address/i);
+    expect(mockTrust.getTier).not.toHaveBeenCalled();
+  });
+
+  it('returns error when SDK throws', async () => {
+    mockTrust.getTier.mockRejectedValue(new Error('network timeout'));
+    mockTrust.getScore.mockResolvedValue({ score: 0 });
+
+    const result = await runCheck({ address: VALID_ADDR });
+    expect(result.error).toBe('network timeout');
+    expect(result.tier).toBe(0);
+  });
+
+  it('uses base-sepolia rpc when network is base-sepolia', async () => {
+    mockTrust.getTier.mockResolvedValue({ tier: 0 });
+    mockTrust.getScore.mockResolvedValue({ score: 0 });
+
+    await runCheck({ address: VALID_ADDR, network: 'base-sepolia' });
+    // No throw = correct network handled
+    expect(mockTrust.getTier).toHaveBeenCalled();
+  });
+});
+
+// ─── agent_trust_query ────────────────────────────────────────────────────────
+
+describe('runQuery', () => {
+  it('returns all attestation types when type is all', async () => {
+    const payments = [{ uid: '0x1' }];
+    const tasks = [{ uid: '0x2' }, { uid: '0x3' }];
+    const audits: unknown[] = [];
+
+    mockTrust.getPaymentReliability.mockResolvedValue(payments);
+    mockTrust.getTaskCompletions.mockResolvedValue(tasks);
+    mockTrust.getSecurityAudits.mockResolvedValue(audits);
+
+    const result = await runQuery({ address: VALID_ADDR, type: 'all' });
+
+    expect(result.address).toBe(VALID_ADDR);
+    expect(result.paymentReliable).toEqual(payments);
+    expect(result.taskCompletion).toEqual(tasks);
+    expect(result.securityAudit).toEqual(audits);
+    expect(result.summary.totalAttestations).toBe(3);
+    expect(result.summary.byType['PaymentReliable']).toBe(1);
+    expect(result.summary.byType['TaskCompletion']).toBe(2);
+    expect(result.summary.byType['SecurityAudit']).toBe(0);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('fetches only PaymentReliable when type is specified', async () => {
+    mockTrust.getPaymentReliability.mockResolvedValue([{ uid: '0x1' }]);
+
+    const result = await runQuery({ address: VALID_ADDR, type: 'PaymentReliable' });
+
+    expect(mockTrust.getPaymentReliability).toHaveBeenCalled();
+    expect(mockTrust.getTaskCompletions).not.toHaveBeenCalled();
+    expect(mockTrust.getSecurityAudits).not.toHaveBeenCalled();
+    expect(result.paymentReliable).toHaveLength(1);
+    expect(result.taskCompletion).toBeUndefined();
+  });
+
+  it('fetches only TaskCompletion when type is specified', async () => {
+    mockTrust.getTaskCompletions.mockResolvedValue([{ uid: '0xabc' }]);
+
+    const result = await runQuery({ address: VALID_ADDR, type: 'TaskCompletion' });
+
+    expect(mockTrust.getTaskCompletions).toHaveBeenCalled();
+    expect(mockTrust.getPaymentReliability).not.toHaveBeenCalled();
+    expect(result.taskCompletion).toHaveLength(1);
+  });
+
+  it('returns error for invalid address', async () => {
+    const result = await runQuery({ address: 'bad' });
+    expect(result.error).toMatch(/invalid address/i);
+    expect(result.summary.totalAttestations).toBe(0);
+    expect(mockTrust.getPaymentReliability).not.toHaveBeenCalled();
+  });
+
+  it('defaults type to all when not specified', async () => {
+    mockTrust.getPaymentReliability.mockResolvedValue([]);
+    mockTrust.getTaskCompletions.mockResolvedValue([]);
+    mockTrust.getSecurityAudits.mockResolvedValue([]);
+
+    await runQuery({ address: VALID_ADDR });
+
+    expect(mockTrust.getPaymentReliability).toHaveBeenCalled();
+    expect(mockTrust.getTaskCompletions).toHaveBeenCalled();
+    expect(mockTrust.getSecurityAudits).toHaveBeenCalled();
+  });
+
+  it('returns error when SDK throws', async () => {
+    mockTrust.getPaymentReliability.mockRejectedValue(new Error('rpc error'));
+    mockTrust.getTaskCompletions.mockResolvedValue([]);
+    mockTrust.getSecurityAudits.mockResolvedValue([]);
+
+    const result = await runQuery({ address: VALID_ADDR, type: 'all' });
+    expect(result.error).toBe('rpc error');
+  });
+});
+
+// ─── agent_trust_issue ────────────────────────────────────────────────────────
+
+describe('runIssue', () => {
+  it('returns error when AGENT_TRUST_PRIVATE_KEY is not set', async () => {
+    const result = await runIssue({ type: 'PaymentReliable', subjectAgent: VALID_ADDR });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/AGENT_TRUST_PRIVATE_KEY/);
+  });
+
+  it('returns error for invalid subjectAgent address', async () => {
+    process.env['AGENT_TRUST_PRIVATE_KEY'] = '0x' + 'f'.repeat(64);
+    const result = await runIssue({ type: 'PaymentReliable', subjectAgent: 'bad-address' });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/invalid subjectAgent/i);
+  });
+
+  it('returns error for missing type', async () => {
+    process.env['AGENT_TRUST_PRIVATE_KEY'] = '0x' + 'f'.repeat(64);
+    // @ts-expect-error testing missing type
+    const result = await runIssue({ subjectAgent: VALID_ADDR });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/type/i);
+  });
+
+  it('issues PaymentReliable attestation successfully', async () => {
+    process.env['AGENT_TRUST_PRIVATE_KEY'] = '0x' + 'f'.repeat(64);
+    mockTrust.issuePaymentReliable.mockResolvedValue({
+      attestationUid: '0xuid123',
+      txHash: '0xtx456',
+    });
+
+    const result = await runIssue({
+      type: 'PaymentReliable',
+      subjectAgent: VALID_ADDR,
+      amount: 1.5,
+      currency: 'ETH',
+      outcome: 'paid',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.attestationUid).toBe('0xuid123');
+    expect(result.txHash).toBe('0xtx456');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('issues TaskCompletion attestation successfully', async () => {
+    process.env['AGENT_TRUST_PRIVATE_KEY'] = '0x' + 'f'.repeat(64);
+    mockTrust.issueTaskCompletion.mockResolvedValue({
+      attestationUid: '0xuid789',
+      txHash: '0xtxabc',
+    });
+
+    const result = await runIssue({
+      type: 'TaskCompletion',
+      subjectAgent: VALID_ADDR,
+      taskId: 'task-001',
+      category: 'defi',
+      taskOutcome: 'completed',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.attestationUid).toBe('0xuid789');
+  });
+
+  it('issues SecurityAudit attestation successfully', async () => {
+    process.env['AGENT_TRUST_PRIVATE_KEY'] = '0x' + 'f'.repeat(64);
+    mockTrust.issueSecurityAudit.mockResolvedValue({
+      attestationUid: '0xuidaudit',
+      txHash: '0xtxaudit',
+    });
+
+    const result = await runIssue({
+      type: 'SecurityAudit',
+      subjectAgent: VALID_ADDR,
+      auditType: 'smart-contract',
+      passed: true,
+      severity: 1,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.attestationUid).toBe('0xuidaudit');
+  });
+
+  it('returns error when SDK throws during issue', async () => {
+    process.env['AGENT_TRUST_PRIVATE_KEY'] = '0x' + 'f'.repeat(64);
+    mockTrust.issuePaymentReliable.mockRejectedValue(new Error('tx reverted'));
+
+    const result = await runIssue({ type: 'PaymentReliable', subjectAgent: VALID_ADDR });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('tx reverted');
+  });
+});

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*", "bin/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}


### PR DESCRIPTION
## What was built

Implements Issue #31 — `@nia-agent-cyber/agent-trust-mcp`, a new package in `packages/mcp/` that exposes Agent Trust SDK methods as MCP tools, enabling Claude Desktop and any MCP-compatible agent runtime to query and issue trust attestations.

**Three tools exposed:**
- `agent_trust_check` — read trust tier + score for an agent address (read-only)
- `agent_trust_issue` — write a PaymentReliable, TaskCompletion, or SecurityAudit attestation on-chain (requires `AGENT_TRUST_PRIVATE_KEY`)
- `agent_trust_query` — fetch full attestation history for an agent address (read-only)

**Package structure mirrors `packages/langchain/`:** separate package.json, peerDeps pattern, `publishConfig: { access: "public" }`.

## How to test locally

```bash
cd packages/mcp
npm install
npm run build
npm test        # 21 unit tests, no live blockchain calls
```

To test with Claude Desktop, add to `claude_desktop_config.json`:

```json
{
  "mcpServers": {
    "agent-trust": {
      "command": "node",
      "args": ["/path/to/agent-trust/packages/mcp/dist/bin/agent-trust-mcp.js"]
    }
  }
}
```

## Claude Desktop config snippet (after npm install -g)

```json
{
  "mcpServers": {
    "agent-trust": {
      "command": "agent-trust-mcp",
      "env": {
        "AGENT_TRUST_PRIVATE_KEY": "optional - only for issuing attestations"
      }
    }
  }
}
```

See `packages/mcp/README.md` for full setup instructions.

Closes #31